### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/xtaci/grasshopper/security/code-scanning/1](https://github.com/xtaci/grasshopper/security/code-scanning/1)

In general, the fix is to explicitly add a `permissions:` block to the workflow (or to each job) that grants only the minimal set of privileges the workflow actually needs. For a simple CI workflow that checks out code and runs `go build` and `go test`, `contents: read` is sufficient; no write access or additional scopes are required.

The best fix here, without changing any existing behavior of the steps, is to add a top‑level `permissions:` block so that it applies to the `build` job (and any future jobs unless they override it). This should be placed after the `on:` block and before `jobs:` in `.github/workflows/go.yml`. The block should set `contents: read`, as suggested by the CodeQL message, which allows `actions/checkout@v4` to function while removing unnecessary write capabilities of `GITHUB_TOKEN`. No imports or additional definitions are needed; this is purely a YAML configuration change inside the workflow file.

Concretely, edit `.github/workflows/go.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and the `jobs:` section. All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
